### PR TITLE
Added Uptekk Hit% option

### DIFF
--- a/DropBox Tracker/configuration.lua
+++ b/DropBox Tracker/configuration.lua
@@ -648,6 +648,11 @@ local function ConfigurationWindow(configuration)
                         if success then
                             this.changed = true
                         end
+
+                        if imgui.Checkbox("Uptekk Hit%", _configuration.UptekkHit) then
+                            _configuration.UptekkHit = not _configuration.UptekkHit
+                            this.changed = true
+                        end
                         
                         dropPreview("Low Hit Weapons", "LowHitCommonWeapon", trkIdx, AdditionalW)
                         dropPreview("High Hit Weapons", "HighHitCommonWeapon", trkIdx, AdditionalW)

--- a/DropBox Tracker/init.lua
+++ b/DropBox Tracker/init.lua
@@ -40,6 +40,7 @@ local function LoadOptions()
     -- If options loaded, make sure we have all those we need
     SetDefaultValue( options, "configurationEnableWindow", true )
     SetDefaultValue( options, "enable", true )
+    SetDefaultValue( options, "UptekkHit", false )
     SetDefaultValue( options, "ignoreMeseta", false )
     SetDefaultValue( options, "maxNumTrackers", 100 )
     SetDefaultValue( options, "numTrackers", 25 )
@@ -1148,7 +1149,12 @@ local function ProcessWeapon(item, floor, trkIdx)
                 AddWeaponSpecial(item,options[trkIdx]["HighHitCommonWeapon"].includeSpecial)
                 AddWeaponAtrributes(item,options[trkIdx]["HighHitCommonWeapon"].includeAtrributes,options[trkIdx]["HighHitCommonWeapon"].includeHit)
                 ItemAppendVisibilityData( options[trkIdx]["HighHitCommonWeapon"], item, trkIdx )
-            -- Show Claire's Deal 5 items
+            elseif options.UptekkHit and item.weapon.untekked and item.weapon.stats[6] > 0 and item.weapon.stats[6] >= options[trkIdx].HighHitCommonWeapon.HitMin - 10 then
+                    item.wName = { { item.name, nil } }
+                    AddWeaponSpecial(item,options[trkIdx]["HighHitCommonWeapon"].includeSpecial)
+                    AddWeaponAtrributes(item,options[trkIdx]["HighHitCommonWeapon"].includeAtrributes,options[trkIdx]["HighHitCommonWeapon"].includeHit)
+                    ItemAppendVisibilityData( options[trkIdx]["HighHitCommonWeapon"], item, trkIdx )
+                -- Show Claire's Deal 5 items
             elseif options[trkIdx].ClairesDeal.enabled and clairesDealLoaded and lib_claires_deal.IsClairesDealItem(item) then
                 ItemAppendVisibilityData( options[trkIdx]["ClairesDeal"], item, trkIdx )
             elseif item.weapon.stats[6] < options[trkIdx].HighHitCommonWeapon.HitMin then


### PR DESCRIPTION
Added Uptekk Hit% toggle to Dropbox Tracker options. When enabled, untekked common weapons will be treated as though they were 10 hit higher, in order to account for uptekking attributes.

Weapons with no special, or weapons that are already tekked, are treated the same whether this is disabled or enabled and must have a minimum of HitMin hit% to be shown on the item reader